### PR TITLE
New PathReader features

### DIFF
--- a/kedro_projetaai/utils/readers.py
+++ b/kedro_projetaai/utils/readers.py
@@ -36,6 +36,7 @@ from kedro_projetaai.utils.extra_datasets_utils.path_patterns import (
 import pandas as pd
 import re
 import logging
+import importlib
 from kedro.io import AbstractDataSet
 from fsspec.utils import infer_storage_options
 from fsspec import filesystem
@@ -54,6 +55,7 @@ class DatasetTypes(Enum):
     parquet = (pd.read_parquet, pd.DataFrame.to_parquet)
     csv = (pd.read_csv, pd.DataFrame.to_csv)
     xlsx = (pd.read_excel, pd.DataFrame.to_excel)
+    xlsm = (pd.read_excel, pd.DataFrame.to_excel)
     json = (pd.read_json, pd.DataFrame.to_json)
     pickle = (pickle_load, pickle_dump)
 
@@ -186,14 +188,21 @@ class BaseDataset(AbstractDataSet):  # type: ignore
 
     def _generate_last_day(self, first_day: pd.Timestamp) -> pd.Timestamp:
         """
-        Generates the last day based on the first day and the history_length.
+        Generates the last day based on the first day and read_args.
+        If min_date on read_args will filter files starting from it.
+        If not, use a rolling window based on the history_length and
+        time_scale args.
 
         This is used to filter the files in the given path.
         """
-        last_day = first_day - pd.DateOffset(
-            **{self.read_args["time_scale"]: self.read_args["history_length"]}
-        )
-        last_day = last_day - pd.Timedelta(days=self._generate_days_difference())
+        if 'min_date' in self.read_args.keys():
+            last_day = pd.to_datetime(self.read_args['min_date'], format='%Y-%m-%d')
+
+        else:
+            last_day = first_day - pd.DateOffset(
+                **{self.read_args["time_scale"]: self.read_args["history_length"]}
+            )
+            last_day = last_day - pd.Timedelta(days=self._generate_days_difference())
         return last_day.normalize()
 
     def _generate_days_difference(self) -> int:
@@ -227,7 +236,36 @@ class BaseDataset(AbstractDataSet):  # type: ignore
         if isinstance(df, pd.DataFrame):
             return df.astype(self.dtypes)
         return df
+    
+    def _build_regex(self, folder_path):
+        """
+        Transform a path string using * wildcards to a regex pattern
+        so it can be used to filter files on PathReader
+        Args:
+            folder_path(str): path containing * wildcards
+        Returns:
+            Regex pattern string
 
+        Example:
+            '{DATALAKE}/20*/features_*.parquet' will return a regex pattern
+            that matches every parquet file that has 'features_' in its name
+            and is inside folders starting with 20.
+        """
+        opts = re.compile('([.]|[*][*]/|[*]|[?])|(.)')
+        out = ''
+        for (pattern_match, literal_text) in opts.findall(folder_path):
+            if pattern_match == '.':
+                out += '[.]'
+            elif pattern_match == '**/':
+                out += '(?:.*/)?'
+            elif pattern_match == '*':
+                out += '[^/]*'
+            elif pattern_match == '?':
+                out += '.'
+            elif literal_text:
+                out += literal_text
+        return out
+    
     def _save(self, df: pd.DataFrame, path: str) -> None:
         """The default save method for all classes that inherit from this class.
 
@@ -527,7 +565,8 @@ class PathReader(BaseDataset):
     def _setting_read_args(self, read_args: Optional[dict[str, Any]]):
         """Raises an error if the read_args is None."""
         self.read_args = {} if read_args is None else read_args
-        self._transform_time_scale()
+        if 'min_date' not in self.read_args:
+            self._transform_time_scale() # not needed if min_date is passed
         return
 
     def _validate_read_args_config(self) -> str:
@@ -558,9 +597,44 @@ class PathReader(BaseDataset):
         date_str = self._transform_to_timestamp(date_str, format=date_format)
         return first_day >= date_str >= last_day
 
+
+    def _str_to_function(self, func_string) -> tuple[callable, str]:
+        """Converts a function string to (callable, args) tuple"""
+        import_string, args_string = func_string.split('(', maxsplit=1)
+        args_string = args_string.removesuffix(')')
+        import_string = import_string.rsplit('.', maxsplit=1)
+        func = getattr(importlib.import_module(import_string[0]), import_string[1])
+        return func, args_string
+
+    def _apply_filefunc(self, df) -> pd.DataFrame:
+        """
+        Applies a function passed in the read arguments to a pandas dataframe.
+        Target function first argument must always be 'df'. 
+        """
+        func, args_string = self._str_to_function(self.read_args['file_func'])
+        return func(eval(args_string)) if args_string == 'df' else func(*eval(args_string))
+    
+    def _apply_pathfunc(self, paths) -> list[str]:
+        """
+        Applies a function passed in the read arguments to a path list. 
+        Target function first argument must always be 'paths'. 
+        """
+        func, args_string = self._str_to_function(self.read_args['path_func'])
+        return func(eval(args_string)) if args_string == 'paths' else func(*eval(args_string))
+
     def _get_paths(self) -> list[str]:
-        path_list = self._filesystem.find(self.path)
-        if path_list is False:
+        # Ensures a path that is compatible with _filesystem.find
+        safe_path = self.path.split('*')[0].rsplit('/', maxsplit=1)[0]
+        path_list = self._filesystem.find(safe_path)
+
+        if 'path_func' in self.read_args:
+            path_list = self._apply_pathfunc(path_list)
+
+        if len(self.path.split('*')) > 0:
+            regex_folder = self._build_regex(self.path.removeprefix(f"{self.protocol}://"))
+            path_list = [path for path in path_list if re.search(regex_folder, path)]
+
+        if (path_list is False) | (path_list == []):
             raise ValueError(
                 f"""No files found in the given path
                 please check if it's correct: {self.path}"""
@@ -595,6 +669,16 @@ class PathReader(BaseDataset):
         """Reads the file in the given path and returns a pandas dataframe."""
         path = self._add_protocol_to_path(path)
         df = super()._load(path=path)
+
+        df['origin'] = path # Path as columns for versioning necessities
+
+        # Apply a function on each loaded dataframe before concatenating
+        if 'file_func' in self.read_args:
+            df = self._apply_filefunc(df)
+
+        if not(self.read_args.get('keep_origin_col', False)):
+            df = df.drop(columns = ['origin'])
+        
         return df
 
     def _load(self, path: Optional[str] = None) -> pd.DataFrame:


### PR DESCRIPTION
Added the following features to PathReader, none of which impact current catalog configurations:

- Filtering the date of files based on a minimum date (min_date parameters on read_args) instead of only through a moving window (history_length and time_scale)
- Allows using a wildcard(*) on path arg to solve specific cases where only the last date is not enough to determine if a file should be loaded
- Applying a function passed as a string on read_args to paths to more advanced filtering
- Setting the file name as a column on loaded dataframes. Useful when the file have no versioning column in it
- Applying a function passed as a string on read_args during file loading, before the concat of all read dataframes. The main objective is to allow files to be treated individualy, grouped, filtered, have specific columns created to reduce memory usage while and after using the PathReader. Example: A daily dataset that will be only used in monthly aggregation can consume much less resources during the parallel I/O of multiple files if it is grouped right after loading and not after loading all the files. This is very important for low RAM environments